### PR TITLE
[#8] Implement backend for Reset Password screen

### DIFF
--- a/data/src/main/java/co/nimblehq/chorn/survey/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/co/nimblehq/chorn/survey/data/repository/AuthRepositoryImpl.kt
@@ -5,6 +5,8 @@ import co.nimblehq.chorn.survey.data.request.LoginRequest
 import co.nimblehq.chorn.survey.data.response.toToken
 import co.nimblehq.chorn.survey.data.service.AuthService
 import co.nimblehq.chorn.survey.data.model.ApiCredential
+import co.nimblehq.chorn.survey.data.request.ResetPasswordRequest
+import co.nimblehq.chorn.survey.data.request.ResetPasswordRequest.*
 import co.nimblehq.chorn.survey.data.storage.*
 import co.nimblehq.chorn.survey.domain.model.Token
 import co.nimblehq.chorn.survey.domain.repository.AuthRepository
@@ -27,6 +29,15 @@ class AuthRepositoryImpl(
         token?.let {
             saveTokens(it)
         } ?: throw Exception("Unable to parse response")
+    }
+
+    override fun resetPassword(email: String): Flow<Unit> = flowTransform {
+        val resetPasswordRequest = ResetPasswordRequest(
+            user = User(email),
+            clientId = apiCredential.clientId,
+            clientSecret = apiCredential.clientSecret
+        )
+        authService.resetPassword(resetPasswordRequest)
     }
 
     private fun saveTokens(token: Token) {

--- a/data/src/main/java/co/nimblehq/chorn/survey/data/request/ResetPasswordRequest.kt
+++ b/data/src/main/java/co/nimblehq/chorn/survey/data/request/ResetPasswordRequest.kt
@@ -1,0 +1,17 @@
+package co.nimblehq.chorn.survey.data.request
+
+import com.squareup.moshi.Json
+
+data class ResetPasswordRequest(
+    @Json(name = "user")
+    val user: User,
+    @Json(name = "client_id")
+    val clientId: String,
+    @Json(name = "client_secret")
+    val clientSecret: String
+) {
+    data class User(
+        @Json(name = "email")
+        val email: String
+    )
+}

--- a/data/src/main/java/co/nimblehq/chorn/survey/data/service/AuthService.kt
+++ b/data/src/main/java/co/nimblehq/chorn/survey/data/service/AuthService.kt
@@ -1,6 +1,7 @@
 package co.nimblehq.chorn.survey.data.service
 
 import co.nimblehq.chorn.survey.data.request.LoginRequest
+import co.nimblehq.chorn.survey.data.request.ResetPasswordRequest
 import co.nimblehq.chorn.survey.data.response.Response
 import co.nimblehq.chorn.survey.data.response.TokenResponse
 import retrofit2.http.Body
@@ -10,4 +11,7 @@ interface AuthService {
 
     @POST("/api/v1/oauth/token")
     suspend fun login(@Body loginRequest: LoginRequest): Response<TokenResponse>
+
+    @POST("/api/v1/passwords")
+    suspend fun resetPassword(@Body resetPasswordRequest: ResetPasswordRequest)
 }

--- a/data/src/test/java/co/nimblehq/chorn/survey/data/repository/AuthRepositoryTest.kt
+++ b/data/src/test/java/co/nimblehq/chorn/survey/data/repository/AuthRepositoryTest.kt
@@ -41,7 +41,7 @@ class AuthRepositoryTest {
     }
 
     @Test
-    fun `When calling login successfully, it emits Unit`() = runTest {
+    fun `When calling login successfully, it emits Unit and saves tokens`() = runTest {
         val tokenResponse = TokenResponse(
             accessToken = "accessToken",
             tokenType = "tokenType",
@@ -69,6 +69,25 @@ class AuthRepositoryTest {
         coEvery { mockAuthService.login(any()) } throws expected
 
         repository.login(email, password).catch {
+            it shouldBe expected
+        }.collect()
+    }
+
+    @Test
+    fun `When calling resetPassword successfully, it emits Unit`() = runTest {
+        coEvery { mockAuthService.resetPassword(any()) } returns Unit
+
+        repository.resetPassword(email).collect {
+            it shouldBe Unit
+        }
+    }
+
+    @Test
+    fun `When calling resetPassword failed, it throws the corresponding error`() = runTest {
+        val expected = Throwable()
+        coEvery { mockAuthService.resetPassword(any()) } throws expected
+
+        repository.resetPassword(email).catch {
             it shouldBe expected
         }.collect()
     }

--- a/domain/src/main/java/co/nimblehq/chorn/survey/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/co/nimblehq/chorn/survey/domain/repository/AuthRepository.kt
@@ -5,4 +5,6 @@ import kotlinx.coroutines.flow.Flow
 interface AuthRepository {
 
     fun login(email: String, password: String): Flow<Unit>
+
+    fun resetPassword(email: String): Flow<Unit>
 }

--- a/domain/src/main/java/co/nimblehq/chorn/survey/domain/usecase/ResetPasswordUseCase.kt
+++ b/domain/src/main/java/co/nimblehq/chorn/survey/domain/usecase/ResetPasswordUseCase.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.chorn.survey.domain.usecase
+
+import co.nimblehq.chorn.survey.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ResetPasswordUseCase @Inject constructor(private val repository: AuthRepository) {
+
+    operator fun invoke(email: String): Flow<Unit> = repository.resetPassword(email)
+}

--- a/domain/src/test/java/co/nimblehq/chorn/survey/domain/usecase/ResetPasswordUseCaseTest.kt
+++ b/domain/src/test/java/co/nimblehq/chorn/survey/domain/usecase/ResetPasswordUseCaseTest.kt
@@ -1,0 +1,41 @@
+package co.nimblehq.chorn.survey.domain.usecase
+
+import co.nimblehq.chorn.survey.domain.repository.AuthRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ResetPasswordUseCaseTest {
+
+    private val mockAuthRepository: AuthRepository = mockk()
+    private val email = "email"
+
+    private lateinit var useCase: ResetPasswordUseCase
+
+    @Before
+    fun setUp() {
+        useCase = ResetPasswordUseCase(mockAuthRepository)
+    }
+
+    @Test
+    fun `When executing use case and repository returns success, it emits Unit`() = runTest {
+        every { mockAuthRepository.resetPassword(any()) } returns flowOf(Unit)
+
+        useCase(email).collect { it shouldBe Unit }
+    }
+
+    @Test
+    fun `When executing use case and repository returns error, it throws the corresponding error`() =
+        runTest {
+            val expected = Exception()
+            every { mockAuthRepository.resetPassword(any()) } returns flow { throw expected }
+
+            useCase(email).catch { it shouldBe expected }.collect()
+        }
+}


### PR DESCRIPTION
#8

## What happened 👀

Implement backend for Reset Password functionality
- [x] Create the `ResetPasswordRequest`
- [x] Add Reset Password API call function inside `AuthService`
- [x] Add service call function inside `AuthRepository` and corresponding unit tests
- [x] Create the `ResetPasswordUseCase` and corresponding unit tests

## Insight 📝

N/A

## Proof Of Work 📹

```
2023-02-20 17:57:39.675  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  --> POST https://survey-api.nimblehq.co/api/v1/passwords
2023-02-20 17:57:39.675  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  Content-Type: application/json; charset=UTF-8
2023-02-20 17:57:39.675  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  Content-Length: 152
2023-02-20 17:57:39.675  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  {"user":{"email":"a@gmail.com"},"client_id":"4gg3bokkvPnMxWz7HHTdM_wf1RNg9k8iA6sZ2ZrA7EA","client_secret":"y_GgV-GEjWd3VTzbZBS6tqEco0E68QuqHQv0QND2vKo"}
2023-02-20 17:57:39.675  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  --> END POST (152-byte body)
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  <-- 200 https://survey-api.nimblehq.co/api/v1/passwords (1061ms)
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  date: Mon, 20 Feb 2023 10:57:41 GMT
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  content-type: application/json; charset=utf-8
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-frame-options: SAMEORIGIN
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-xss-protection: 1; mode=block
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-content-type-options: nosniff
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-download-options: noopen
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-permitted-cross-domain-policies: none
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  referrer-policy: strict-origin-when-cross-origin
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  vary: Accept-Encoding, Origin
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  etag: W/"5f37e0d76b1c24d94db0840dbba33995"
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  cache-control: max-age=0, private, must-revalidate
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-request-id: e6a09e79-219a-4cc3-b193-94866ead0215
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  x-runtime: 0.009267
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  strict-transport-security: max-age=31536000; includeSubDomains
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  via: 1.1 vegur
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  cf-cache-status: DYNAMIC
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=2g9LlcV02P4sW%2Fp3oNJImhgg6WDTZu71v0cyJvu3qC9E9L2eM4p9mPhrJf7szMcirPV6ivro2kaiuAhgih8hCoG6fYTy62e3MRbDWocV9am0d3OGgzGdja5BNtmlUZk3pZFtzmsVuCR%2F"}],"group":"cf-nel","max_age":604800}
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  server: cloudflare
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  cf-ray: 79c6b90389522709-BKK
2023-02-20 17:57:40.737  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
2023-02-20 17:57:40.741  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  {"meta":{"message":"If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."}}
2023-02-20 17:57:40.741  1464-1580  okhttp.OkHttpClient     co.nimblehq.chorn.survey             I  <-- END HTTP (150-byte body)
```
